### PR TITLE
Add runtime event and crash isolation seam

### DIFF
--- a/apps/service/src/lib/runtime-adapter.mjs
+++ b/apps/service/src/lib/runtime-adapter.mjs
@@ -26,8 +26,11 @@ function createRuntimeHealthSnapshot(config, runtimeState, store, supervisorStat
       lastActivatedAt: supervisorStatus.lastActivatedAt,
       lastReleasedAt: supervisorStatus.lastReleasedAt,
       lastCommandAt: supervisorStatus.lastCommandAt,
+      lastCrashAt: supervisorStatus.lastCrashAt,
       commandDispatchCount: supervisorStatus.commandDispatchCount,
+      crashCount: supervisorStatus.crashCount,
       lastCommand: supervisorStatus.lastCommand,
+      lastCrash: supervisorStatus.lastCrash,
       activeRouteActivationCount: supervisorStatus.activeRouteActivationCount,
       activeRouteActivations: supervisorStatus.activeRouteActivations,
       manifestRegistry: supervisorStatus.manifestRegistry,
@@ -49,6 +52,16 @@ function createRuntimeSupervisorNotReadyError(supervisorStatus) {
 function createRuntimeCommandActivationIdError() {
   const error = new Error('Runtime command dispatch requires a non-empty activationId.');
   error.code = 'runtime-command-invalid';
+  error.statusCode = 400;
+  error.details = {
+    field: 'activationId'
+  };
+  return error;
+}
+
+function createRuntimeCrashActivationIdError() {
+  const error = new Error('Runtime helper crash reporting requires a non-empty activationId.');
+  error.code = 'runtime-helper-crash-invalid';
   error.statusCode = 400;
   error.details = {
     field: 'activationId'
@@ -92,6 +105,9 @@ export function createInProcessRuntimeAdapter({
     listRouteActivations() {
       return runtimeSupervisor.listRouteActivations();
     },
+    listRuntimeEvents() {
+      return runtimeSupervisor.listEvents();
+    },
     async dispatchRouteCommand(activationId, commandEnvelope) {
       if (!runtimeSupervisor.isReady()) {
         throw createRuntimeSupervisorNotReadyError(runtimeSupervisor.getStatus());
@@ -108,6 +124,15 @@ export function createInProcessRuntimeAdapter({
         surfaceKind: activation.surface.surfaceKind,
         echoedPayload: command.payload
       }));
+    },
+    reportRouteHelperCrash(activationId, crashEnvelope) {
+      if (!runtimeSupervisor.isReady()) {
+        throw createRuntimeSupervisorNotReadyError(runtimeSupervisor.getStatus());
+      }
+      if (typeof activationId !== 'string' || activationId.trim().length === 0) {
+        throw createRuntimeCrashActivationIdError();
+      }
+      return runtimeSupervisor.reportHelperCrash(activationId, crashEnvelope);
     },
     releaseRouteActivation(activationId) {
       return runtimeSupervisor.releaseRouteActivation(activationId);

--- a/apps/service/src/lib/runtime-supervisor.mjs
+++ b/apps/service/src/lib/runtime-supervisor.mjs
@@ -29,6 +29,17 @@ function normalizeCommandFailure(error, at, commandType) {
   };
 }
 
+function normalizeHelperCrashFailure(error, at, activationId, slotId, helperPackageId) {
+  return {
+    at,
+    activationId,
+    slotId,
+    helperPackageId,
+    code: typeof error?.code === 'string' ? error.code : 'runtime-helper-crash',
+    message: error?.message ?? `Helper slot ${slotId} crashed.`
+  };
+}
+
 function createCommandValidationError(message, details = null) {
   const error = new Error(message);
   error.code = 'runtime-command-invalid';
@@ -54,7 +65,14 @@ function summarizeHelperSlot(slot) {
     slotId: slot.slotId,
     status: slot.status,
     helperPackageId: slot.helper?.packageId ?? null,
-    sourceRuntime: slot.helper?.sourceRuntime ?? null
+    sourceRuntime: slot.helper?.sourceRuntime ?? null,
+    restartCount: 0,
+    restartWindowStartedAt: null,
+    restartWindowCount: 0,
+    lastCrashAt: null,
+    lastRestartedAt: null,
+    lastFailure: null,
+    failurePolicy: slot.helper?.failurePolicy ?? null
   };
 }
 
@@ -65,6 +83,36 @@ function summarizeDiagnostic(diagnostic) {
     slotId: diagnostic.slotId ?? null,
     helperPackageId: diagnostic.helperPackageId ?? null,
     message: diagnostic.message ?? 'Runtime activation diagnostic.'
+  };
+}
+
+function ensureHelperCrashEnvelope(crashEnvelope) {
+  if (!crashEnvelope || typeof crashEnvelope !== 'object' || Array.isArray(crashEnvelope)) {
+    throw createCommandValidationError('Runtime helper crash reporting requires a JSON object payload.');
+  }
+
+  if (typeof crashEnvelope.slotId !== 'string' || crashEnvelope.slotId.trim().length === 0) {
+    throw createCommandValidationError('Runtime helper crash field slotId must be a non-empty string.', {
+      field: 'slotId'
+    });
+  }
+
+  if (crashEnvelope.code !== undefined && (typeof crashEnvelope.code !== 'string' || crashEnvelope.code.trim().length === 0)) {
+    throw createCommandValidationError('Runtime helper crash field code must be omitted or be a non-empty string.', {
+      field: 'code'
+    });
+  }
+
+  if (crashEnvelope.message !== undefined && (typeof crashEnvelope.message !== 'string' || crashEnvelope.message.trim().length === 0)) {
+    throw createCommandValidationError('Runtime helper crash field message must be omitted or be a non-empty string.', {
+      field: 'message'
+    });
+  }
+
+  return {
+    slotId: crashEnvelope.slotId.trim(),
+    code: typeof crashEnvelope.code === 'string' ? crashEnvelope.code.trim() : 'runtime-helper-crash',
+    message: typeof crashEnvelope.message === 'string' ? crashEnvelope.message.trim() : 'Synthetic helper crash report.'
   };
 }
 
@@ -172,12 +220,51 @@ function createCommandRecord(commandEnvelope, activationRecord, commandResult, d
   };
 }
 
+function createHelperCrashDiagnostic(slotId, helperPackageId, failure) {
+  return {
+    level: 'warning',
+    code: 'helper-crash-isolated',
+    slotId,
+    helperPackageId,
+    message: `${failure.code}: ${failure.message}`
+  };
+}
+
+function upsertActivationDiagnostic(diagnostics, nextDiagnostic) {
+  return [
+    ...diagnostics.filter((diagnostic) => !(diagnostic.slotId === nextDiagnostic.slotId && diagnostic.code === nextDiagnostic.code)),
+    nextDiagnostic
+  ];
+}
+
 function createActivationNotFoundError(activationId) {
   const error = new Error(`Runtime activation ${activationId} is not active.`);
   error.code = 'runtime-activation-not-found';
   error.statusCode = 404;
   error.details = {
     activationId
+  };
+  return error;
+}
+
+function createHelperSlotNotFoundError(activationId, slotId) {
+  const error = new Error(`Runtime helper slot ${slotId} is not active for activation ${activationId}.`);
+  error.code = 'runtime-helper-slot-not-found';
+  error.statusCode = 404;
+  error.details = {
+    activationId,
+    slotId
+  };
+  return error;
+}
+
+function createHelperSlotNotBoundError(activationId, slotId) {
+  const error = new Error(`Runtime helper slot ${slotId} is not bound for activation ${activationId}.`);
+  error.code = 'runtime-helper-slot-not-bound';
+  error.statusCode = 409;
+  error.details = {
+    activationId,
+    slotId
   };
   return error;
 }
@@ -201,8 +288,11 @@ export function createRuntimeSupervisor({
     lastActivatedAt: null,
     lastReleasedAt: null,
     lastCommandAt: null,
+    lastCrashAt: null,
     commandDispatchCount: 0,
+    crashCount: 0,
     lastCommand: null,
+    lastCrash: null,
     manifestRegistry: null,
     activeRouteActivations: [],
     lastFailure: null,
@@ -235,12 +325,25 @@ export function createRuntimeSupervisor({
       lastActivatedAt: state.lastActivatedAt,
       lastReleasedAt: state.lastReleasedAt,
       lastCommandAt: state.lastCommandAt,
+      lastCrashAt: state.lastCrashAt,
       commandDispatchCount: state.commandDispatchCount,
+      crashCount: state.crashCount,
       lastCommand: state.lastCommand ? {
         ...state.lastCommand,
         result: state.lastCommand.result && typeof state.lastCommand.result === 'object'
           ? { ...state.lastCommand.result }
           : state.lastCommand.result
+      } : null,
+      lastCrash: state.lastCrash ? {
+        ...state.lastCrash,
+        failure: state.lastCrash.failure ? { ...state.lastCrash.failure } : null,
+        helperSlot: state.lastCrash.helperSlot ? {
+          ...state.lastCrash.helperSlot,
+          failurePolicy: state.lastCrash.helperSlot.failurePolicy
+            ? { ...state.lastCrash.helperSlot.failurePolicy }
+            : null,
+          lastFailure: state.lastCrash.helperSlot.lastFailure ? { ...state.lastCrash.helperSlot.lastFailure } : null
+        } : null
       } : null,
       manifestRegistry: state.manifestRegistry,
       activeRouteActivationCount: state.activeRouteActivations.length,
@@ -255,7 +358,11 @@ export function createRuntimeSupervisor({
             : activation.lastCommand.result
         } : null,
         lastCommandFailure: activation.lastCommandFailure ? { ...activation.lastCommandFailure } : null,
-        helperSlots: activation.helperSlots.map((slot) => ({ ...slot })),
+        helperSlots: activation.helperSlots.map((slot) => ({
+          ...slot,
+          failurePolicy: slot.failurePolicy ? { ...slot.failurePolicy } : null,
+          lastFailure: slot.lastFailure ? { ...slot.lastFailure } : null
+        })),
         diagnostics: activation.diagnostics.map((diagnostic) => ({ ...diagnostic }))
       })),
       lastFailure: state.lastFailure,
@@ -414,6 +521,132 @@ export function createRuntimeSupervisor({
     },
     listRouteActivations() {
       return getStatus().activeRouteActivations;
+    },
+    listEvents() {
+      return getStatus().recentEvents;
+    },
+    reportHelperCrash(activationId, crashEnvelope) {
+      const recordIndex = state.activeRouteActivations.findIndex((entry) => entry.activationId === activationId);
+      if (recordIndex === -1) {
+        throw createActivationNotFoundError(activationId);
+      }
+
+      const activation = state.activeRouteActivations[recordIndex];
+      const normalizedCrash = ensureHelperCrashEnvelope(crashEnvelope);
+      const slotIndex = activation.helperSlots.findIndex((slot) => slot.slotId === normalizedCrash.slotId);
+      if (slotIndex === -1) {
+        throw createHelperSlotNotFoundError(activationId, normalizedCrash.slotId);
+      }
+
+      const slot = activation.helperSlots[slotIndex];
+      if (!slot.helperPackageId) {
+        throw createHelperSlotNotBoundError(activationId, normalizedCrash.slotId);
+      }
+
+      const crashedAt = timestamp(now);
+      const failure = normalizeHelperCrashFailure(
+        normalizedCrash,
+        crashedAt,
+        activationId,
+        slot.slotId,
+        slot.helperPackageId
+      );
+      slot.lastCrashAt = crashedAt;
+      slot.lastFailure = failure;
+      state.lastCrashAt = crashedAt;
+      state.crashCount += 1;
+
+      recordEvent('helper-crash-reported', {
+        activationId,
+        slotId: slot.slotId,
+        helperPackageId: slot.helperPackageId,
+        code: failure.code
+      });
+
+      const failurePolicy = slot.failurePolicy ?? {};
+      const maxRestartsPerHour = Number(failurePolicy.maxRestartsPerHour ?? 0);
+      const restartBudgetStartedAt = slot.restartWindowStartedAt
+        ? Date.parse(slot.restartWindowStartedAt)
+        : Number.NaN;
+      const crashedAtValue = Date.parse(crashedAt);
+      if (!slot.restartWindowStartedAt || Number.isNaN(restartBudgetStartedAt) || Number.isNaN(crashedAtValue) || (crashedAtValue - restartBudgetStartedAt) >= 3_600_000) {
+        slot.restartWindowStartedAt = crashedAt;
+        slot.restartWindowCount = 0;
+      }
+
+      if (failurePolicy.onCrash === 'restartable' && slot.restartWindowCount < maxRestartsPerHour) {
+        slot.status = 'restarting';
+        recordEvent('helper-restart-scheduled', {
+          activationId,
+          slotId: slot.slotId,
+          helperPackageId: slot.helperPackageId,
+          nextRestartCount: slot.restartCount + 1
+        });
+        slot.restartCount += 1;
+        slot.restartWindowCount += 1;
+        slot.lastRestartedAt = timestamp(now);
+        slot.status = 'bound';
+        activation.diagnostics = activation.diagnostics.filter((diagnostic) => !(diagnostic.slotId === slot.slotId && diagnostic.code === 'helper-crash-isolated'));
+        state.lastCrash = {
+          activationId,
+          slotId: slot.slotId,
+          helperPackageId: slot.helperPackageId,
+          crashedAt,
+          recoveryAction: 'restarted',
+          failure,
+          helperSlot: {
+            ...slot,
+            failurePolicy: slot.failurePolicy ? { ...slot.failurePolicy } : null,
+            lastFailure: slot.lastFailure ? { ...slot.lastFailure } : null
+          }
+        };
+        recordEvent('helper-restarted', {
+          activationId,
+          slotId: slot.slotId,
+          helperPackageId: slot.helperPackageId,
+          restartCount: slot.restartCount
+        });
+      }
+      else {
+        slot.status = 'degraded';
+        activation.diagnostics = upsertActivationDiagnostic(
+          activation.diagnostics,
+          createHelperCrashDiagnostic(slot.slotId, slot.helperPackageId, failure)
+        );
+        state.lastCrash = {
+          activationId,
+          slotId: slot.slotId,
+          helperPackageId: slot.helperPackageId,
+          crashedAt,
+          recoveryAction: 'degraded',
+          failure,
+          helperSlot: {
+            ...slot,
+            failurePolicy: slot.failurePolicy ? { ...slot.failurePolicy } : null,
+            lastFailure: slot.lastFailure ? { ...slot.lastFailure } : null
+          }
+        };
+        recordEvent('helper-crash-isolated', {
+          activationId,
+          slotId: slot.slotId,
+          helperPackageId: slot.helperPackageId,
+          code: failure.code
+        });
+      }
+
+      return {
+        activationId,
+        slotId: slot.slotId,
+        helperPackageId: slot.helperPackageId,
+        crashedAt,
+        recoveryAction: state.lastCrash.recoveryAction,
+        failure,
+        helperSlot: {
+          ...slot,
+          failurePolicy: slot.failurePolicy ? { ...slot.failurePolicy } : null,
+          lastFailure: slot.lastFailure ? { ...slot.lastFailure } : null
+        }
+      };
     },
     releaseRouteActivation(activationId) {
       const recordIndex = state.activeRouteActivations.findIndex((entry) => entry.activationId === activationId);

--- a/apps/service/src/server.mjs
+++ b/apps/service/src/server.mjs
@@ -216,6 +216,10 @@ async function routeApi(request, response, runtimeAdapter, config) {
     return sendJson(request, response, config, 200, runtimeAdapter.listRouteActivations());
   }
 
+  if (request.method === 'GET' && url.pathname === '/api/runtime/events') {
+    return sendJson(request, response, config, 200, runtimeAdapter.listRuntimeEvents());
+  }
+
   if (request.method === 'POST' && url.pathname === '/api/runtime/route-activations/commands') {
     const commandEnvelope = await readBody(request);
     return sendJson(
@@ -224,6 +228,17 @@ async function routeApi(request, response, runtimeAdapter, config) {
       config,
       200,
       await runtimeAdapter.dispatchRouteCommand(commandEnvelope.activationId, commandEnvelope)
+    );
+  }
+
+  if (request.method === 'POST' && url.pathname === '/api/runtime/route-activations/helper-crashes') {
+    const crashEnvelope = await readBody(request);
+    return sendJson(
+      request,
+      response,
+      config,
+      200,
+      runtimeAdapter.reportRouteHelperCrash(crashEnvelope.activationId, crashEnvelope)
     );
   }
 

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1608,6 +1608,19 @@ function summarizeLastRuntimeCommand(health) {
   return `${lastCommand.commandType} at ${formatTimestamp(lastCommand.completedAt ?? lastCommand.dispatchedAt)}`;
 }
 
+function summarizeRuntimeCrashCount(health) {
+  return String(health?.runtime?.crashCount ?? 0);
+}
+
+function summarizeLastRuntimeCrash(health) {
+  const lastCrash = health?.runtime?.lastCrash ?? null;
+  if (!lastCrash?.slotId) {
+    return 'No runtime helper crash recorded yet';
+  }
+
+  return `${lastCrash.slotId} ${lastCrash.recoveryAction ?? 'reported'} at ${formatTimestamp(lastCrash.crashedAt)}`;
+}
+
 function currentRouteActivationRequest() {
   const directConversation = currentDirectConversation();
   if (directConversation) {
@@ -1919,6 +1932,14 @@ function renderHealth() {
       <div class="service-health-metric service-health-metric-wide">
         <span class="eyebrow">Last command</span>
         <strong>${escapeHtml(summarizeLastRuntimeCommand(state.health))}</strong>
+      </div>
+      <div class="service-health-metric">
+        <span class="eyebrow">Crashes</span>
+        <strong>${escapeHtml(summarizeRuntimeCrashCount(state.health))}</strong>
+      </div>
+      <div class="service-health-metric service-health-metric-wide">
+        <span class="eyebrow">Last crash</span>
+        <strong>${escapeHtml(summarizeLastRuntimeCrash(state.health))}</strong>
       </div>
       <div class="service-health-metric service-health-metric-wide">
         <span class="eyebrow">Supervisor event</span>

--- a/apps/web/public/project-progress.json
+++ b/apps/web/public/project-progress.json
@@ -1,10 +1,10 @@
 {
   "title": "Project Pulse",
-  "capturedAt": "2026-04-10T01:35:22+09:00",
-  "capturedAtLabel": "Reviewed Apr 10, 2026, 01:35 JST",
-  "summary": "Issue #57 has moved forward again: the runtime supervisor now owns active route-command dispatch and lifecycle transitions in addition to retained route activations, the health surface shows command ownership directly, and the NEXUS project board remains aligned with repo truth.",
-  "source": "GitHub-first NEXUS truth sweep on Apr 10, 2026 JST, plus verified branch coverage for supervisor-owned runtime command dispatch, lifecycle control, and operator-visible health updates.",
-  "nextAction": "Publish the active #57 command-dispatch delta, keep the new health-surface visibility truthful in the client, and continue the deeper runtime event and crash-isolation seam behind the supervisor boundary.",
+  "capturedAt": "2026-04-10T01:51:53+09:00",
+  "capturedAtLabel": "Reviewed Apr 10, 2026, 01:51 JST",
+  "summary": "Issue #57 has moved forward again: the runtime supervisor now exposes additive runtime event listing, owns helper-crash isolation with restart-or-degrade behavior, and the health surface shows crash state alongside route and command ownership.",
+  "source": "GitHub-first NEXUS truth sweep on Apr 10, 2026 JST, plus verified branch coverage for supervisor-owned runtime events, helper-crash isolation, and operator-visible health updates.",
+  "nextAction": "Publish the active #57 runtime-event and crash-isolation delta, keep the new health-surface visibility truthful in the client, and continue the deeper native-runtime ownership seam behind the supervisor boundary.",
   "lanes": [
     {
       "kind": "PR",
@@ -33,7 +33,7 @@
       "ref": "#54",
       "status": "done",
       "title": "Desktop readiness validation",
-      "summary": "Continuity validation closed cleanly on the Electron and Node baseline, and the merged repo remains green with 83 out of 83 automated checks after the later runtime command-dispatch coverage landed.",
+      "summary": "Continuity validation closed cleanly on the Electron and Node baseline, and the active runtime branch is green with 86 out of 86 automated checks after the later runtime event and crash-isolation coverage landed.",
       "nextAction": "Use the verified baseline as the migration source for the next runtime-topology work.",
       "artifacts": [
         {
@@ -183,8 +183,8 @@
       "ref": "#57",
       "status": "execute-now",
       "title": "Packaging and runtime topology",
-      "summary": "With #56 shipped, the runtime-topology lane is active again. The degraded runtime supervisor seam now retains active route-activation state, owns additive runtime command dispatch and lifecycle transitions, and surfaces both route and command ownership in health without breaking the current HTTP contract.",
-      "nextAction": "Publish the active runtime command-dispatch delta, then continue moving runtime events and crash-isolation ownership behind the supervisor seam.",
+      "summary": "With #56 shipped, the runtime-topology lane is active again. The degraded runtime supervisor seam now retains active route-activation state, owns additive runtime command dispatch, runtime event listing, and helper-crash restart/degrade isolation, and surfaces route, command, and crash ownership in health without breaking the current HTTP contract.",
+      "nextAction": "Publish the active runtime-event and crash-isolation delta, then continue moving deeper native-runtime lifecycle ownership behind the supervisor seam.",
       "artifacts": [
         {
           "label": "First migration seam record",

--- a/test/service.test.mjs
+++ b/test/service.test.mjs
@@ -45,8 +45,11 @@ test('service boots and exposes the seeded internal channel map', async () => {
     assert.equal(health.runtime.backingImplementation, 'in-process-store');
     assert.equal(health.runtime.lifecycleState, 'running');
     assert.equal(health.runtime.lastCommandAt, null);
+    assert.equal(health.runtime.lastCrashAt, null);
     assert.equal(health.runtime.commandDispatchCount, 0);
+    assert.equal(health.runtime.crashCount, 0);
     assert.equal(health.runtime.lastCommand, null);
+    assert.equal(health.runtime.lastCrash, null);
     assert.equal(health.runtime.activeRouteActivationCount, 0);
     assert.deepEqual(health.runtime.activeRouteActivations, []);
     assert.equal(health.runtime.manifestRegistry.surfacePackageCount, 4);
@@ -422,6 +425,127 @@ test('runtime command dispatch is retained as supervisor-owned lifecycle state',
   });
 });
 
+test('runtime helper crash is isolated and restartable helper slots recover behind the supervisor seam', async () => {
+  await withService(async (service) => {
+    const activation = await fetch(`${service.url}/api/runtime/route-activations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        actorId: 'identity-jack',
+        workspaceId: 'workspace-internal-core',
+        surfaceKind: 'thread',
+        scopeId: 'thread-roadmap-71',
+        surfacePackageId: 'nexus.surface.thread',
+        routeCapabilities: [
+          'conversation.read',
+          'message.compose'
+        ],
+        helperSlotRequests: [
+          {
+            slotId: 'thread-sidebar',
+            preferredHelperPackageId: 'symbiosis.helper.review'
+          }
+        ]
+      })
+    }).then((response) => response.json());
+
+    const crashResponse = await fetch(`${service.url}/api/runtime/route-activations/helper-crashes`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        activationId: activation.activationId,
+        slotId: 'thread-sidebar',
+        code: 'TEST_HELPER_CRASH',
+        message: 'Synthetic helper crash for restart coverage.'
+      })
+    });
+    const crash = await crashResponse.json();
+
+    assert.equal(crashResponse.status, 200);
+    assert.equal(crash.activationId, activation.activationId);
+    assert.equal(crash.slotId, 'thread-sidebar');
+    assert.equal(crash.helperPackageId, 'symbiosis.helper.review');
+    assert.equal(crash.recoveryAction, 'restarted');
+    assert.equal(crash.failure.code, 'TEST_HELPER_CRASH');
+    assert.equal(crash.helperSlot.status, 'bound');
+    assert.equal(crash.helperSlot.restartCount, 1);
+
+    const eventsResponse = await fetch(`${service.url}/api/runtime/events`);
+    const events = await eventsResponse.json();
+    assert.equal(eventsResponse.status, 200);
+    assert(events.some((event) => event.type === 'helper-crash-reported'));
+    assert(events.some((event) => event.type === 'helper-restart-scheduled'));
+    assert(events.some((event) => event.type === 'helper-restarted'));
+
+    const activeActivations = await fetch(`${service.url}/api/runtime/route-activations`).then((response) => response.json());
+    assert.equal(activeActivations.length, 1);
+    assert.equal(activeActivations[0].helperSlots[0].status, 'bound');
+    assert.equal(activeActivations[0].helperSlots[0].restartCount, 1);
+    assert.equal(activeActivations[0].helperSlots[0].lastFailure.code, 'TEST_HELPER_CRASH');
+
+    const health = await fetch(`${service.url}/api/health`).then((response) => response.json());
+    assert.equal(health.runtime.crashCount, 1);
+    assert.equal(health.runtime.lastCrash.slotId, 'thread-sidebar');
+    assert.equal(health.runtime.lastCrash.recoveryAction, 'restarted');
+    assert.equal(health.runtime.activeRouteActivations[0].helperSlots[0].restartCount, 1);
+    assert(health.runtime.supervisor.recentEvents.some((event) => event.type === 'helper-crash-reported'));
+    assert(health.runtime.supervisor.recentEvents.some((event) => event.type === 'helper-restarted'));
+  });
+});
+
+test('runtime helper crash degrades a slot once the restart budget is exhausted', async () => {
+  await withService(async (service) => {
+    const activation = await fetch(`${service.url}/api/runtime/route-activations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        actorId: 'identity-jack',
+        workspaceId: 'workspace-internal-core',
+        surfaceKind: 'thread',
+        scopeId: 'thread-roadmap-71',
+        surfacePackageId: 'nexus.surface.thread',
+        routeCapabilities: [
+          'conversation.read'
+        ],
+        helperSlotRequests: [
+          {
+            slotId: 'thread-sidebar',
+            preferredHelperPackageId: 'symbiosis.helper.review'
+          }
+        ]
+      })
+    }).then((response) => response.json());
+
+    for (let attempt = 1; attempt <= 4; attempt += 1) {
+      const crashResponse = await fetch(`${service.url}/api/runtime/route-activations/helper-crashes`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          activationId: activation.activationId,
+          slotId: 'thread-sidebar',
+          code: `TEST_HELPER_CRASH_${attempt}`,
+          message: `Synthetic helper crash ${attempt}.`
+        })
+      });
+      const crash = await crashResponse.json();
+      assert.equal(crashResponse.status, 200);
+      assert.equal(crash.activationId, activation.activationId);
+    }
+
+    const activeActivations = await fetch(`${service.url}/api/runtime/route-activations`).then((response) => response.json());
+    assert.equal(activeActivations.length, 1);
+    assert.equal(activeActivations[0].helperSlots[0].status, 'degraded');
+    assert.equal(activeActivations[0].helperSlots[0].restartCount, 3);
+    assert(activeActivations[0].diagnostics.some((diagnostic) => diagnostic.code === 'helper-crash-isolated'));
+
+    const health = await fetch(`${service.url}/api/health`).then((response) => response.json());
+    assert.equal(health.runtime.crashCount, 4);
+    assert.equal(health.runtime.lastCrash.recoveryAction, 'degraded');
+    assert.equal(health.runtime.activeRouteActivations[0].helperSlots[0].status, 'degraded');
+    assert(health.runtime.supervisor.recentEvents.some((event) => event.type === 'helper-crash-isolated'));
+  });
+});
+
 test('releasing an unknown runtime activation returns a stable not-found error', async () => {
   await withService(async (service) => {
     const releaseResponse = await fetch(
@@ -494,6 +618,65 @@ test('runtime command dispatch rejects unsupported capability use and invalid pa
     const missing = await missingResponse.json();
     assert.equal(missingResponse.status, 404);
     assert.equal(missing.code, 'runtime-activation-not-found');
+  });
+});
+
+test('runtime helper crash reporting rejects invalid activation and slot requests', async () => {
+  await withService(async (service) => {
+    const missingActivationResponse = await fetch(`${service.url}/api/runtime/route-activations/helper-crashes`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        activationId: 'route-activation-missing',
+        slotId: 'thread-sidebar',
+        code: 'TEST_HELPER_CRASH'
+      })
+    });
+    const missingActivation = await missingActivationResponse.json();
+    assert.equal(missingActivationResponse.status, 404);
+    assert.equal(missingActivation.code, 'runtime-activation-not-found');
+
+    const activation = await fetch(`${service.url}/api/runtime/route-activations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        actorId: 'identity-jack',
+        workspaceId: 'workspace-internal-core',
+        surfaceKind: 'thread',
+        scopeId: 'thread-roadmap-71',
+        surfacePackageId: 'nexus.surface.thread',
+        routeCapabilities: [
+          'conversation.read'
+        ],
+        helperSlotRequests: []
+      })
+    }).then((response) => response.json());
+
+    const invalidPayloadResponse = await fetch(`${service.url}/api/runtime/route-activations/helper-crashes`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        activationId: activation.activationId,
+        slotId: ''
+      })
+    });
+    const invalidPayload = await invalidPayloadResponse.json();
+    assert.equal(invalidPayloadResponse.status, 400);
+    assert.equal(invalidPayload.code, 'runtime-command-invalid');
+    assert.equal(invalidPayload.details.field, 'slotId');
+
+    const missingSlotResponse = await fetch(`${service.url}/api/runtime/route-activations/helper-crashes`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        activationId: activation.activationId,
+        slotId: 'thread-sidebar',
+        code: 'TEST_HELPER_CRASH'
+      })
+    });
+    const missingSlot = await missingSlotResponse.json();
+    assert.equal(missingSlotResponse.status, 404);
+    assert.equal(missingSlot.code, 'runtime-helper-slot-not-found');
   });
 });
 


### PR DESCRIPTION
## Summary
- add supervisor-owned runtime event listing and helper crash reporting behind the existing service/runtime seam
- isolate helper crashes with restart-or-degrade behavior and surface crash state through health plus Project Pulse
- extend service coverage for runtime events, helper crash recovery, degraded crash handling, and crash-report validation

## Verification
- `node --check apps/service/src/lib/runtime-supervisor.mjs`
- `node --check apps/service/src/lib/runtime-adapter.mjs`
- `node --check apps/service/src/server.mjs`
- `node --check apps/web/public/app.js`
- `npm test` (`86/86`)

Refs #57