### PR TITLE
Add runtime lifecycle request ownership

### DIFF
--- a/apps/service/src/lib/runtime-adapter.mjs
+++ b/apps/service/src/lib/runtime-adapter.mjs
@@ -27,10 +27,14 @@ function createRuntimeHealthSnapshot(config, runtimeState, store, supervisorStat
       lastReleasedAt: supervisorStatus.lastReleasedAt,
       lastCommandAt: supervisorStatus.lastCommandAt,
       lastCrashAt: supervisorStatus.lastCrashAt,
+      lastLifecycleRequestAt: supervisorStatus.lastLifecycleRequestAt,
       commandDispatchCount: supervisorStatus.commandDispatchCount,
       crashCount: supervisorStatus.crashCount,
+      lifecycleRequestCount: supervisorStatus.lifecycleRequestCount,
+      acceptingRouteActivations: supervisorStatus.acceptingRouteActivations,
       lastCommand: supervisorStatus.lastCommand,
       lastCrash: supervisorStatus.lastCrash,
+      lastLifecycleRequest: supervisorStatus.lastLifecycleRequest,
       activeRouteActivationCount: supervisorStatus.activeRouteActivationCount,
       activeRouteActivations: supervisorStatus.activeRouteActivations,
       manifestRegistry: supervisorStatus.manifestRegistry,
@@ -66,6 +70,13 @@ function createRuntimeCrashActivationIdError() {
   error.details = {
     field: 'activationId'
   };
+  return error;
+}
+
+function createRuntimeLifecycleRequestError() {
+  const error = new Error('Runtime lifecycle requests require a JSON object payload.');
+  error.code = 'runtime-lifecycle-invalid';
+  error.statusCode = 400;
   return error;
 }
 
@@ -107,6 +118,15 @@ export function createInProcessRuntimeAdapter({
     },
     listRuntimeEvents() {
       return runtimeSupervisor.listEvents();
+    },
+    requestRuntimeLifecycle(lifecycleEnvelope) {
+      if (!runtimeSupervisor.isReady()) {
+        throw createRuntimeSupervisorNotReadyError(runtimeSupervisor.getStatus());
+      }
+      if (!lifecycleEnvelope || typeof lifecycleEnvelope !== 'object' || Array.isArray(lifecycleEnvelope)) {
+        throw createRuntimeLifecycleRequestError();
+      }
+      return runtimeSupervisor.requestLifecycle(lifecycleEnvelope);
     },
     async dispatchRouteCommand(activationId, commandEnvelope) {
       if (!runtimeSupervisor.isReady()) {

--- a/apps/service/src/lib/runtime-supervisor.mjs
+++ b/apps/service/src/lib/runtime-supervisor.mjs
@@ -2,6 +2,7 @@ import { createId } from './ids.mjs';
 
 const DEFAULT_EVENT_LIMIT = 10;
 const ALLOWED_LIFECYCLE_STATES = new Set(['active', 'background', 'suspended', 'draining']);
+const ALLOWED_RUNTIME_LIFECYCLE_REQUESTS = new Set(['drain', 'resume', 'stop-requested']);
 
 function timestamp(now) {
   const value = now();
@@ -48,6 +49,22 @@ function createCommandValidationError(message, details = null) {
   return error;
 }
 
+function createLifecycleValidationError(message, details = null) {
+  const error = new Error(message);
+  error.code = 'runtime-lifecycle-invalid';
+  error.statusCode = 400;
+  error.details = details;
+  return error;
+}
+
+function createLifecycleConflictError(message, details = null) {
+  const error = new Error(message);
+  error.code = 'runtime-lifecycle-conflict';
+  error.statusCode = 409;
+  error.details = details;
+  return error;
+}
+
 function createCommandCapabilityDeniedError(activationId, commandType, requiredCapability) {
   const error = new Error(`Runtime activation ${activationId} is not approved to dispatch ${commandType} with capability ${requiredCapability}.`);
   error.code = 'runtime-command-capability-denied';
@@ -83,6 +100,37 @@ function summarizeDiagnostic(diagnostic) {
     slotId: diagnostic.slotId ?? null,
     helperPackageId: diagnostic.helperPackageId ?? null,
     message: diagnostic.message ?? 'Runtime activation diagnostic.'
+  };
+}
+
+function ensureLifecycleRequestEnvelope(lifecycleEnvelope) {
+  if (!lifecycleEnvelope || typeof lifecycleEnvelope !== 'object' || Array.isArray(lifecycleEnvelope)) {
+    throw createLifecycleValidationError('Runtime lifecycle requests require a JSON object payload.');
+  }
+
+  if (typeof lifecycleEnvelope.requestType !== 'string' || lifecycleEnvelope.requestType.trim().length === 0) {
+    throw createLifecycleValidationError('Runtime lifecycle field requestType must be a non-empty string.', {
+      field: 'requestType'
+    });
+  }
+
+  const requestType = lifecycleEnvelope.requestType.trim();
+  if (!ALLOWED_RUNTIME_LIFECYCLE_REQUESTS.has(requestType)) {
+    throw createLifecycleValidationError(`Runtime lifecycle request ${requestType} is not supported.`, {
+      field: 'requestType',
+      allowedValues: [...ALLOWED_RUNTIME_LIFECYCLE_REQUESTS]
+    });
+  }
+
+  if (lifecycleEnvelope.reason !== undefined && (typeof lifecycleEnvelope.reason !== 'string' || lifecycleEnvelope.reason.trim().length === 0)) {
+    throw createLifecycleValidationError('Runtime lifecycle field reason must be omitted or be a non-empty string.', {
+      field: 'reason'
+    });
+  }
+
+  return {
+    requestType,
+    reason: typeof lifecycleEnvelope.reason === 'string' ? lifecycleEnvelope.reason.trim() : null
   };
 }
 
@@ -220,6 +268,19 @@ function createCommandRecord(commandEnvelope, activationRecord, commandResult, d
   };
 }
 
+function createLifecycleRequestRecord(requestEnvelope, previousLifecycleState, nextLifecycleState, requestedAt, dispatchOwner, targetOwner) {
+  return {
+    requestId: createId('runtime-lifecycle-request'),
+    requestType: requestEnvelope.requestType,
+    reason: requestEnvelope.reason,
+    requestedAt,
+    previousLifecycleState,
+    nextLifecycleState,
+    dispatchOwner,
+    targetOwner
+  };
+}
+
 function createHelperCrashDiagnostic(slotId, helperPackageId, failure) {
   return {
     level: 'warning',
@@ -269,6 +330,16 @@ function createHelperSlotNotBoundError(activationId, slotId) {
   return error;
 }
 
+function createRouteActivationLifecycleConflictError(lifecycleState) {
+  const error = new Error(`Runtime lifecycle state ${lifecycleState} is not accepting new route activations.`);
+  error.code = 'runtime-lifecycle-not-accepting-activations';
+  error.statusCode = 409;
+  error.details = {
+    lifecycleState
+  };
+  return error;
+}
+
 export function createRuntimeSupervisor({
   manifestRegistry,
   now = () => new Date(),
@@ -289,10 +360,13 @@ export function createRuntimeSupervisor({
     lastReleasedAt: null,
     lastCommandAt: null,
     lastCrashAt: null,
+    lastLifecycleRequestAt: null,
     commandDispatchCount: 0,
     crashCount: 0,
+    lifecycleRequestCount: 0,
     lastCommand: null,
     lastCrash: null,
+    lastLifecycleRequest: null,
     manifestRegistry: null,
     activeRouteActivations: [],
     lastFailure: null,
@@ -326,14 +400,18 @@ export function createRuntimeSupervisor({
       lastReleasedAt: state.lastReleasedAt,
       lastCommandAt: state.lastCommandAt,
       lastCrashAt: state.lastCrashAt,
+      lastLifecycleRequestAt: state.lastLifecycleRequestAt,
       commandDispatchCount: state.commandDispatchCount,
       crashCount: state.crashCount,
+      lifecycleRequestCount: state.lifecycleRequestCount,
+      acceptingRouteActivations: state.readiness === 'ready' && state.lifecycleState === 'running',
       lastCommand: state.lastCommand ? {
         ...state.lastCommand,
         result: state.lastCommand.result && typeof state.lastCommand.result === 'object'
           ? { ...state.lastCommand.result }
           : state.lastCommand.result
       } : null,
+      lastLifecycleRequest: state.lastLifecycleRequest ? { ...state.lastLifecycleRequest } : null,
       lastCrash: state.lastCrash ? {
         ...state.lastCrash,
         failure: state.lastCrash.failure ? { ...state.lastCrash.failure } : null,
@@ -426,6 +504,9 @@ export function createRuntimeSupervisor({
       return getStatus();
     },
     async activateRoute(activateRoute) {
+      if (state.lifecycleState !== 'running') {
+        throw createRouteActivationLifecycleConflictError(state.lifecycleState);
+      }
       const activation = await activateRoute();
       const record = createActivationRecord(activation);
       state.activeRouteActivations = [
@@ -518,6 +599,78 @@ export function createRuntimeSupervisor({
         });
         throw error;
       }
+    },
+    requestLifecycle(lifecycleEnvelope) {
+      const normalizedRequest = ensureLifecycleRequestEnvelope(lifecycleEnvelope);
+      const previousLifecycleState = state.lifecycleState;
+      let nextLifecycleState = previousLifecycleState;
+
+      if (state.readiness !== 'ready') {
+        throw createLifecycleConflictError(
+          `Runtime lifecycle requests cannot be applied while the supervisor is ${state.readiness}.`,
+          {
+            requestType: normalizedRequest.requestType,
+            lifecycleState: state.lifecycleState,
+            readiness: state.readiness
+          }
+        );
+      }
+
+      if (normalizedRequest.requestType === 'drain') {
+        if (state.lifecycleState !== 'running') {
+          throw createLifecycleConflictError('Runtime drain requests are only accepted while the supervisor is running.', {
+            requestType: normalizedRequest.requestType,
+            lifecycleState: state.lifecycleState
+          });
+        }
+        nextLifecycleState = 'draining';
+      }
+      else if (normalizedRequest.requestType === 'resume') {
+        if (!['draining', 'stop-requested'].includes(state.lifecycleState)) {
+          throw createLifecycleConflictError('Runtime resume requests are only accepted from draining or stop-requested state.', {
+            requestType: normalizedRequest.requestType,
+            lifecycleState: state.lifecycleState
+          });
+        }
+        nextLifecycleState = 'running';
+      }
+      else if (normalizedRequest.requestType === 'stop-requested') {
+        if (!['running', 'draining'].includes(state.lifecycleState)) {
+          throw createLifecycleConflictError('Runtime stop-requested requests are only accepted from running or draining state.', {
+            requestType: normalizedRequest.requestType,
+            lifecycleState: state.lifecycleState
+          });
+        }
+        nextLifecycleState = 'stop-requested';
+      }
+
+      const requestedAt = timestamp(now);
+      state.lifecycleState = nextLifecycleState;
+      state.lastLifecycleRequestAt = requestedAt;
+      state.lifecycleRequestCount += 1;
+      const requestRecord = createLifecycleRequestRecord(
+        normalizedRequest,
+        previousLifecycleState,
+        nextLifecycleState,
+        requestedAt,
+        state.owner,
+        state.targetOwner
+      );
+      state.lastLifecycleRequest = requestRecord;
+
+      recordEvent('lifecycle-requested', {
+        requestId: requestRecord.requestId,
+        requestType: requestRecord.requestType,
+        previousLifecycleState,
+        nextLifecycleState
+      });
+      recordEvent(`runtime-${requestRecord.requestType}`, {
+        requestId: requestRecord.requestId,
+        previousLifecycleState,
+        nextLifecycleState
+      });
+
+      return requestRecord;
     },
     listRouteActivations() {
       return getStatus().activeRouteActivations;

--- a/apps/service/src/server.mjs
+++ b/apps/service/src/server.mjs
@@ -220,6 +220,10 @@ async function routeApi(request, response, runtimeAdapter, config) {
     return sendJson(request, response, config, 200, runtimeAdapter.listRuntimeEvents());
   }
 
+  if (request.method === 'POST' && url.pathname === '/api/runtime/lifecycle-requests') {
+    return sendJson(request, response, config, 200, runtimeAdapter.requestRuntimeLifecycle(await readBody(request)));
+  }
+
   if (request.method === 'POST' && url.pathname === '/api/runtime/route-activations/commands') {
     const commandEnvelope = await readBody(request);
     return sendJson(

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1621,6 +1621,25 @@ function summarizeLastRuntimeCrash(health) {
   return `${lastCrash.slotId} ${lastCrash.recoveryAction ?? 'reported'} at ${formatTimestamp(lastCrash.crashedAt)}`;
 }
 
+function summarizeRuntimeLifecycleRequestCount(health) {
+  return String(health?.runtime?.lifecycleRequestCount ?? 0);
+}
+
+function summarizeLastRuntimeLifecycleRequest(health) {
+  const lastLifecycleRequest = health?.runtime?.lastLifecycleRequest ?? null;
+  if (!lastLifecycleRequest?.requestType) {
+    return 'No runtime lifecycle request recorded yet';
+  }
+
+  return `${lastLifecycleRequest.requestType} at ${formatTimestamp(lastLifecycleRequest.requestedAt)}`;
+}
+
+function summarizeRuntimeActivationAcceptance(health) {
+  return health?.runtime?.acceptingRouteActivations === false
+    ? 'Route activation paused'
+    : 'Route activation accepting';
+}
+
 function currentRouteActivationRequest() {
   const directConversation = currentDirectConversation();
   if (directConversation) {
@@ -1929,9 +1948,21 @@ function renderHealth() {
         <span class="eyebrow">Commands</span>
         <strong>${escapeHtml(summarizeRuntimeCommandCount(state.health))}</strong>
       </div>
+      <div class="service-health-metric">
+        <span class="eyebrow">Lifecycle requests</span>
+        <strong>${escapeHtml(summarizeRuntimeLifecycleRequestCount(state.health))}</strong>
+      </div>
       <div class="service-health-metric service-health-metric-wide">
         <span class="eyebrow">Last command</span>
         <strong>${escapeHtml(summarizeLastRuntimeCommand(state.health))}</strong>
+      </div>
+      <div class="service-health-metric service-health-metric-wide">
+        <span class="eyebrow">Last lifecycle</span>
+        <strong>${escapeHtml(summarizeLastRuntimeLifecycleRequest(state.health))}</strong>
+      </div>
+      <div class="service-health-metric service-health-metric-wide">
+        <span class="eyebrow">Activation gate</span>
+        <strong>${escapeHtml(summarizeRuntimeActivationAcceptance(state.health))}</strong>
       </div>
       <div class="service-health-metric">
         <span class="eyebrow">Crashes</span>

--- a/apps/web/public/project-progress.json
+++ b/apps/web/public/project-progress.json
@@ -1,10 +1,10 @@
 {
   "title": "Project Pulse",
-  "capturedAt": "2026-04-10T01:51:53+09:00",
-  "capturedAtLabel": "Reviewed Apr 10, 2026, 01:51 JST",
-  "summary": "Issue #57 has moved forward again: the runtime supervisor now exposes additive runtime event listing, owns helper-crash isolation with restart-or-degrade behavior, and the health surface shows crash state alongside route and command ownership.",
-  "source": "GitHub-first NEXUS truth sweep on Apr 10, 2026 JST, plus verified branch coverage for supervisor-owned runtime events, helper-crash isolation, and operator-visible health updates.",
-  "nextAction": "Publish the active #57 runtime-event and crash-isolation delta, keep the new health-surface visibility truthful in the client, and continue the deeper native-runtime ownership seam behind the supervisor boundary.",
+  "capturedAt": "2026-04-10T06:47:14+09:00",
+  "capturedAtLabel": "Reviewed Apr 10, 2026, 06:47 JST",
+  "summary": "Issue #57 has moved forward again: the runtime supervisor now owns additive runtime lifecycle requests alongside route activation, command dispatch, event listing, and helper-crash isolation, and the health surface shows lifecycle gating directly.",
+  "source": "GitHub-first NEXUS truth sweep on Apr 10, 2026 JST, plus verified branch coverage for supervisor-owned runtime lifecycle requests, lifecycle event ownership, and operator-visible health updates.",
+  "nextAction": "Publish the active #57 runtime lifecycle-request delta, keep the new lifecycle-gate visibility truthful in the client, and continue the deeper runtime log-stream and failure-audit seam behind the supervisor boundary.",
   "lanes": [
     {
       "kind": "PR",
@@ -33,7 +33,7 @@
       "ref": "#54",
       "status": "done",
       "title": "Desktop readiness validation",
-      "summary": "Continuity validation closed cleanly on the Electron and Node baseline, and the active runtime branch is green with 86 out of 86 automated checks after the later runtime event and crash-isolation coverage landed.",
+      "summary": "Continuity validation closed cleanly on the Electron and Node baseline, and the active runtime branch is green with 88 out of 88 automated checks after the later runtime lifecycle-request coverage landed.",
       "nextAction": "Use the verified baseline as the migration source for the next runtime-topology work.",
       "artifacts": [
         {
@@ -183,8 +183,8 @@
       "ref": "#57",
       "status": "execute-now",
       "title": "Packaging and runtime topology",
-      "summary": "With #56 shipped, the runtime-topology lane is active again. The degraded runtime supervisor seam now retains active route-activation state, owns additive runtime command dispatch, runtime event listing, and helper-crash restart/degrade isolation, and surfaces route, command, and crash ownership in health without breaking the current HTTP contract.",
-      "nextAction": "Publish the active runtime-event and crash-isolation delta, then continue moving deeper native-runtime lifecycle ownership behind the supervisor seam.",
+      "summary": "With #56 shipped, the runtime-topology lane is active again. The degraded runtime supervisor seam now retains active route-activation state, owns additive runtime lifecycle requests, command dispatch, event listing, and helper-crash restart/degrade isolation, and surfaces lifecycle, route, command, and crash ownership in health without breaking the current HTTP contract.",
+      "nextAction": "Publish the active runtime lifecycle-request delta, then continue moving deeper runtime log-stream and failure-audit ownership behind the supervisor seam.",
       "artifacts": [
         {
           "label": "First migration seam record",
@@ -212,6 +212,10 @@
         },
         {
           "label": "Runtime command service surface",
+          "path": "apps/service/src/server.mjs"
+        },
+        {
+          "label": "Runtime lifecycle service surface",
           "path": "apps/service/src/server.mjs"
         },
         {

--- a/test/service.test.mjs
+++ b/test/service.test.mjs
@@ -44,12 +44,16 @@ test('service boots and exposes the seeded internal channel map', async () => {
     assert.equal(health.runtime.readiness, 'ready');
     assert.equal(health.runtime.backingImplementation, 'in-process-store');
     assert.equal(health.runtime.lifecycleState, 'running');
+    assert.equal(health.runtime.lastLifecycleRequestAt, null);
     assert.equal(health.runtime.lastCommandAt, null);
     assert.equal(health.runtime.lastCrashAt, null);
     assert.equal(health.runtime.commandDispatchCount, 0);
     assert.equal(health.runtime.crashCount, 0);
+    assert.equal(health.runtime.lifecycleRequestCount, 0);
+    assert.equal(health.runtime.acceptingRouteActivations, true);
     assert.equal(health.runtime.lastCommand, null);
     assert.equal(health.runtime.lastCrash, null);
+    assert.equal(health.runtime.lastLifecycleRequest, null);
     assert.equal(health.runtime.activeRouteActivationCount, 0);
     assert.deepEqual(health.runtime.activeRouteActivations, []);
     assert.equal(health.runtime.manifestRegistry.surfacePackageCount, 4);
@@ -546,6 +550,61 @@ test('runtime helper crash degrades a slot once the restart budget is exhausted'
   });
 });
 
+test('runtime lifecycle requests are retained as supervisor-owned state and emit lifecycle events', async () => {
+  await withService(async (service) => {
+    const drainResponse = await fetch(`${service.url}/api/runtime/lifecycle-requests`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        requestType: 'drain',
+        reason: 'operator-maintenance-window'
+      })
+    });
+    const drain = await drainResponse.json();
+
+    assert.equal(drainResponse.status, 200);
+    assert.match(drain.requestId, /^runtime-lifecycle-request-/);
+    assert.equal(drain.requestType, 'drain');
+    assert.equal(drain.reason, 'operator-maintenance-window');
+    assert.equal(drain.previousLifecycleState, 'running');
+    assert.equal(drain.nextLifecycleState, 'draining');
+    assert.equal(drain.dispatchOwner, 'node-runtime-supervisor');
+    assert.equal(drain.targetOwner, 'native-runtime-supervisor');
+
+    const healthWhileDraining = await fetch(`${service.url}/api/health`).then((response) => response.json());
+    assert.equal(healthWhileDraining.runtime.lifecycleState, 'draining');
+    assert.equal(healthWhileDraining.runtime.lifecycleRequestCount, 1);
+    assert.equal(healthWhileDraining.runtime.acceptingRouteActivations, false);
+    assert.equal(healthWhileDraining.runtime.lastLifecycleRequest.requestId, drain.requestId);
+    assert(healthWhileDraining.runtime.supervisor.recentEvents.some((event) => event.type === 'lifecycle-requested'));
+    assert(healthWhileDraining.runtime.supervisor.recentEvents.some((event) => event.type === 'runtime-drain'));
+
+    const resumeResponse = await fetch(`${service.url}/api/runtime/lifecycle-requests`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        requestType: 'resume',
+        reason: 'maintenance-finished'
+      })
+    });
+    const resume = await resumeResponse.json();
+
+    assert.equal(resumeResponse.status, 200);
+    assert.equal(resume.requestType, 'resume');
+    assert.equal(resume.previousLifecycleState, 'draining');
+    assert.equal(resume.nextLifecycleState, 'running');
+
+    const events = await fetch(`${service.url}/api/runtime/events`).then((response) => response.json());
+    assert(events.some((event) => event.type === 'runtime-resume'));
+
+    const healthAfterResume = await fetch(`${service.url}/api/health`).then((response) => response.json());
+    assert.equal(healthAfterResume.runtime.lifecycleState, 'running');
+    assert.equal(healthAfterResume.runtime.lifecycleRequestCount, 2);
+    assert.equal(healthAfterResume.runtime.acceptingRouteActivations, true);
+    assert.equal(healthAfterResume.runtime.lastLifecycleRequest.requestId, resume.requestId);
+  });
+});
+
 test('releasing an unknown runtime activation returns a stable not-found error', async () => {
   await withService(async (service) => {
     const releaseResponse = await fetch(
@@ -618,6 +677,63 @@ test('runtime command dispatch rejects unsupported capability use and invalid pa
     const missing = await missingResponse.json();
     assert.equal(missingResponse.status, 404);
     assert.equal(missing.code, 'runtime-activation-not-found');
+  });
+});
+
+test('runtime lifecycle requests reject invalid transitions and block route activation while draining', async () => {
+  await withService(async (service) => {
+    const drainResponse = await fetch(`${service.url}/api/runtime/lifecycle-requests`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        requestType: 'drain'
+      })
+    });
+    const drain = await drainResponse.json();
+    assert.equal(drainResponse.status, 200);
+    assert.equal(drain.nextLifecycleState, 'draining');
+
+    const activationResponse = await fetch(`${service.url}/api/runtime/route-activations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        actorId: 'identity-jack',
+        workspaceId: 'workspace-internal-core',
+        surfaceKind: 'thread',
+        scopeId: 'thread-roadmap-71',
+        surfacePackageId: 'nexus.surface.thread',
+        routeCapabilities: [
+          'conversation.read'
+        ],
+        helperSlotRequests: []
+      })
+    });
+    const activation = await activationResponse.json();
+    assert.equal(activationResponse.status, 409);
+    assert.equal(activation.code, 'runtime-lifecycle-not-accepting-activations');
+    assert.equal(activation.details.lifecycleState, 'draining');
+
+    const conflictResponse = await fetch(`${service.url}/api/runtime/lifecycle-requests`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        requestType: 'drain'
+      })
+    });
+    const conflict = await conflictResponse.json();
+    assert.equal(conflictResponse.status, 409);
+    assert.equal(conflict.code, 'runtime-lifecycle-conflict');
+
+    const invalidResponse = await fetch(`${service.url}/api/runtime/lifecycle-requests`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        requestType: 'hibernate'
+      })
+    });
+    const invalid = await invalidResponse.json();
+    assert.equal(invalidResponse.status, 400);
+    assert.equal(invalid.code, 'runtime-lifecycle-invalid');
   });
 });
 


### PR DESCRIPTION
## Summary
- add supervisor-owned runtime lifecycle requests behind the existing service/runtime seam
- expose lifecycle request state through `/api/health` and gate new route activations while the runtime is draining or stop-requested
- refresh the operator-facing health card and Project Pulse snapshot so lifecycle ownership is visible in-product

## Verification
- `node --check apps/service/src/lib/runtime-supervisor.mjs`
- `node --check apps/service/src/lib/runtime-adapter.mjs`
- `node --check apps/service/src/server.mjs`
- `node --check test/service.test.mjs`
- `node --check apps/web/public/app.js`
- JSON parse for `apps/web/public/project-progress.json`
- `npm test` (`88/88`)

Refs #57