### PR TITLE
Codify NEXUS native container architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ The April 1, 2026 direction for future NEXUS desktop work is:
 - Avalonia as the desktop UI host where a managed shell is still useful
 - native C interop as the preferred boundary between the UI host and native runtime components
 - C# only where necessary for Avalonia hosting, glue code, or thin orchestration layers
+- C++ only for narrowly justified component internals when Native C is not viable, hidden behind the Native C boundary
+- NEXUS as a container interface for surface programs and approved helper programs, not a monolithic rewrite of imported runtimes
 
 That means Electron and the current Node-managed desktop shell should be treated as the continuity baseline already present in repo, not the intended long-term desktop stack.
+
+The bounded architecture contract is recorded in [docs/architecture-contract.md](docs/architecture-contract.md).
+The runtime container interface for component programs is recorded in [docs/runtime-container-interface.md](docs/runtime-container-interface.md).
 
 ## Storage modes
 
@@ -162,6 +167,8 @@ Live `POST /api/adapters/discord/events` ingress now persists a relay record for
 - [ANVIL integration contract](docs/anvil-integration-contract.md)
 - [Discord cutover plan](docs/discord-cutover-plan.md)
 - [Hosted service mode](docs/hosted-service-mode.md)
+- [Architecture contract](docs/architecture-contract.md)
+- [Runtime container interface](docs/runtime-container-interface.md)
 - [Runtime topology](docs/runtime-topology.md)
 - [First runtime migration seam](docs/runtime-first-migration-seam.md)
 - [Runtime package manifests](docs/runtime-package-manifests.md)

--- a/apps/service/src/lib/runtime-manifest-registry.mjs
+++ b/apps/service/src/lib/runtime-manifest-registry.mjs
@@ -29,6 +29,8 @@ const HELPER_REQUIRED_FIELDS = [
   'presentationHooks'
 ];
 
+const SUPPORTED_SURFACE_KINDS = new Set(['channel', 'forum', 'thread', 'timeline', 'direct']);
+
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
@@ -61,6 +63,26 @@ function inferManifestType(manifest) {
   throw new Error('Runtime manifest must declare either surfaceKind or sourceRuntime.');
 }
 
+function normalizeNativeEntrypoint(entrypoint, packageId) {
+  if (!entrypoint || typeof entrypoint !== 'object' || Array.isArray(entrypoint)) {
+    throw new Error(`Surface manifest ${packageId} must declare entrypoint as an object.`);
+  }
+
+  if (entrypoint.runtime !== 'native-c') {
+    throw new Error(`Surface manifest ${packageId} must declare entrypoint.runtime as native-c.`);
+  }
+
+  if (!isNonEmptyString(entrypoint.symbol)) {
+    throw new Error(`Surface manifest ${packageId} must declare entrypoint.symbol as a non-empty string.`);
+  }
+
+  return {
+    ...entrypoint,
+    runtime: 'native-c',
+    symbol: entrypoint.symbol.trim()
+  };
+}
+
 function normalizeSurfaceManifest(manifest, sourcePath) {
   assertRequiredFields(manifest, SURFACE_REQUIRED_FIELDS, 'surface');
   const packageId = manifest.packageId;
@@ -68,13 +90,19 @@ function normalizeSurfaceManifest(manifest, sourcePath) {
     throw new Error('surface manifest packageId must be a non-empty string.');
   }
 
+  const surfaceKind = manifest.surfaceKind.trim();
+  if (!SUPPORTED_SURFACE_KINDS.has(surfaceKind)) {
+    throw new Error(`Surface manifest ${packageId} declares unsupported surfaceKind ${surfaceKind}.`);
+  }
+
   return {
     ...manifest,
     packageId: packageId.trim(),
     displayName: manifest.displayName.trim(),
-    surfaceKind: manifest.surfaceKind.trim(),
+    surfaceKind,
     manifestVersion: String(manifest.manifestVersion).trim(),
     abiVersion: String(manifest.abiVersion).trim(),
+    entrypoint: normalizeNativeEntrypoint(manifest.entrypoint, packageId),
     hostCapabilities: toStringArray(manifest.hostCapabilities, 'hostCapabilities', packageId),
     helperSlots: Array.isArray(manifest.helperSlots)
       ? manifest.helperSlots

--- a/apps/web/public/project-progress.json
+++ b/apps/web/public/project-progress.json
@@ -1,10 +1,10 @@
 {
   "title": "Project Pulse",
-  "capturedAt": "2026-04-10T06:47:14+09:00",
-  "capturedAtLabel": "Reviewed Apr 10, 2026, 06:47 JST",
-  "summary": "Issue #57 has moved forward again: the runtime supervisor now owns additive runtime lifecycle requests alongside route activation, command dispatch, event listing, and helper-crash isolation, and the health surface shows lifecycle gating directly.",
-  "source": "GitHub-first NEXUS truth sweep on Apr 10, 2026 JST, plus verified branch coverage for supervisor-owned runtime lifecycle requests, lifecycle event ownership, and operator-visible health updates.",
-  "nextAction": "Publish the active #57 runtime lifecycle-request delta, keep the new lifecycle-gate visibility truthful in the client, and continue the deeper runtime log-stream and failure-audit seam behind the supervisor boundary.",
+  "capturedAt": "2026-04-10T10:39:31+09:00",
+  "capturedAtLabel": "Reviewed Apr 10, 2026, 10:39 JST",
+  "summary": "Issue #57 is being tightened against the approved architecture direction: NEXUS is now explicitly tracked as a Native-C-first runtime container for multiple component programs, with Avalonia as the target host, C# as thin glue, C++ constrained to hidden component internals, and the current UI shifted away from the beige continuity theme toward Matrix Code.",
+  "source": "GitHub-first NEXUS truth sweep on Apr 10, 2026 JST, issue #57 architecture-alignment audit, and local verification of the runtime container contract, timeline surface package, native-c manifest enforcement, and Matrix Code client theme.",
+  "nextAction": "Publish the architecture-alignment delta for #57, then continue the deeper runtime log-stream and failure-audit seam behind the supervisor boundary.",
   "lanes": [
     {
       "kind": "PR",
@@ -183,9 +183,17 @@
       "ref": "#57",
       "status": "execute-now",
       "title": "Packaging and runtime topology",
-      "summary": "With #56 shipped, the runtime-topology lane is active again. The degraded runtime supervisor seam now retains active route-activation state, owns additive runtime lifecycle requests, command dispatch, event listing, and helper-crash restart/degrade isolation, and surfaces lifecycle, route, command, and crash ownership in health without breaking the current HTTP contract.",
-      "nextAction": "Publish the active runtime lifecycle-request delta, then continue moving deeper runtime log-stream and failure-audit ownership behind the supervisor seam.",
+      "summary": "With #56 shipped, the runtime-topology lane is active again. The current alignment slice codifies NEXUS as a Native-C-first runtime container for multiple surface/helper component programs, pins C++ to hidden component internals only when Native C is not viable, adds the named runtime-container interface, extends package coverage to the timeline surface, and gives the continuity UI a Matrix Code theme.",
+      "nextAction": "Publish the architecture-alignment PR and issue writeback, then continue moving deeper runtime log-stream and failure-audit ownership behind the supervisor seam.",
       "artifacts": [
+        {
+          "label": "Architecture contract",
+          "path": "docs/architecture-contract.md"
+        },
+        {
+          "label": "Runtime container interface",
+          "path": "docs/runtime-container-interface.md"
+        },
         {
           "label": "First migration seam record",
           "path": "docs/runtime-first-migration-seam.md"
@@ -197,6 +205,14 @@
         {
           "label": "Runtime topology record",
           "path": "docs/runtime-topology.md"
+        },
+        {
+          "label": "Timeline surface example",
+          "path": "config/runtime-packages/surface-timeline.example.json"
+        },
+        {
+          "label": "Matrix Code client theme",
+          "path": "apps/web/public/styles.css"
         },
         {
           "label": "Runtime supervisor seam",

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1,20 +1,20 @@
 :root {
-  color-scheme: light;
-  --bg: #f2efe7;
-  --bg-deep: #d7dfd6;
-  --panel: rgba(255, 251, 246, 0.92);
-  --panel-strong: rgba(255, 255, 255, 0.96);
-  --ink: #1d2623;
-  --muted: #5f6c66;
-  --line: rgba(29, 38, 35, 0.12);
-  --accent: #0f6b5a;
-  --accent-strong: #0b4e42;
-  --accent-soft: rgba(15, 107, 90, 0.1);
-  --discord: #5166d6;
-  --discord-soft: rgba(81, 102, 214, 0.12);
-  --success: #0b7a56;
-  --error: #9a3b2e;
-  --shadow: 0 22px 48px rgba(34, 42, 38, 0.1);
+  color-scheme: dark;
+  --bg: #020604;
+  --bg-deep: #001a0b;
+  --panel: rgba(0, 18, 8, 0.9);
+  --panel-strong: rgba(1, 34, 14, 0.94);
+  --ink: #dcffe4;
+  --muted: #83b89a;
+  --line: rgba(0, 255, 102, 0.2);
+  --accent: #00ff66;
+  --accent-strong: #76ff9f;
+  --accent-soft: rgba(0, 255, 102, 0.12);
+  --discord: #4df8ff;
+  --discord-soft: rgba(77, 248, 255, 0.14);
+  --success: #00ff66;
+  --error: #ff5f7a;
+  --shadow: 0 22px 48px rgba(0, 0, 0, 0.48);
 }
 
 * {
@@ -31,9 +31,12 @@ body {
   font-family: "Aptos", "Segoe UI", sans-serif;
   color: var(--ink);
   background:
-    radial-gradient(circle at top left, rgba(15, 107, 90, 0.2), transparent 26%),
-    radial-gradient(circle at bottom right, rgba(191, 149, 84, 0.15), transparent 24%),
-    linear-gradient(180deg, #faf6ef 0%, var(--bg) 100%);
+    linear-gradient(90deg, rgba(0, 255, 102, 0.07) 1px, transparent 1px),
+    repeating-linear-gradient(180deg, rgba(0, 255, 102, 0.08) 0 2px, transparent 2px 10px),
+    radial-gradient(circle at top left, rgba(0, 255, 102, 0.22), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(118, 255, 159, 0.14), transparent 26%),
+    linear-gradient(180deg, #000000 0%, var(--bg) 100%);
+  background-size: 48px 100%, 100% 18px, auto, auto, auto;
 }
 
 button,
@@ -104,8 +107,8 @@ textarea {
   border: 1px solid var(--line);
   border-radius: 20px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 251, 246, 0.88)),
-    radial-gradient(circle at top right, rgba(15, 107, 90, 0.08), transparent 34%);
+    linear-gradient(180deg, rgba(1, 42, 18, 0.94), rgba(0, 18, 8, 0.88)),
+    radial-gradient(circle at top right, rgba(0, 255, 102, 0.12), transparent 34%);
 }
 
 .breadcrumb-card-copy {
@@ -127,8 +130,8 @@ textarea {
   min-height: 32px;
   padding: 6px 12px;
   border-radius: 999px;
-  border: 1px solid rgba(15, 107, 90, 0.16);
-  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 255, 102, 0.24);
+  background: rgba(0, 18, 8, 0.9);
   color: var(--accent-strong);
   font-size: 0.82rem;
   font-weight: 700;
@@ -143,20 +146,20 @@ textarea {
 
 .breadcrumb-chip-button:hover:not(:disabled) {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.98);
-  border-color: rgba(15, 107, 90, 0.28);
+  background: rgba(2, 54, 22, 0.98);
+  border-color: rgba(0, 255, 102, 0.42);
 }
 
 .breadcrumb-chip.current {
   background: var(--accent);
-  color: white;
+  color: var(--bg-deep);
   border-color: transparent;
 }
 
 .breadcrumb-placeholder {
   color: var(--muted);
   border-style: dashed;
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(0, 18, 8, 0.7);
 }
 
 .breadcrumb-separator {
@@ -189,7 +192,7 @@ textarea {
   padding: 12px 14px;
   border-radius: 16px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.84);
+  background: rgba(0, 18, 8, 0.84);
   color: inherit;
   text-align: left;
   cursor: pointer;
@@ -198,13 +201,13 @@ textarea {
 
 .route-history-entry:hover:not(:disabled) {
   transform: translateY(-1px);
-  border-color: rgba(15, 107, 90, 0.26);
-  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(0, 255, 102, 0.38);
+  background: rgba(2, 54, 22, 0.96);
 }
 
 .route-history-entry.active {
-  border-color: rgba(15, 107, 90, 0.34);
-  background: rgba(15, 107, 90, 0.08);
+  border-color: rgba(0, 255, 102, 0.5);
+  background: rgba(0, 255, 102, 0.12);
 }
 
 .route-history-entry-label {
@@ -232,7 +235,7 @@ textarea {
   padding: 12px 14px;
   border-radius: 16px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.84);
+  background: rgba(0, 18, 8, 0.84);
   color: inherit;
   text-align: left;
   cursor: pointer;
@@ -241,8 +244,8 @@ textarea {
 
 .recent-card:hover:not(:disabled) {
   transform: translateY(-1px);
-  border-color: rgba(15, 107, 90, 0.26);
-  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(0, 255, 102, 0.38);
+  background: rgba(2, 54, 22, 0.96);
 }
 
 .recent-card-top {
@@ -335,7 +338,7 @@ button {
   border-radius: 999px;
   padding: 11px 18px;
   background: var(--accent);
-  color: white;
+  color: var(--bg-deep);
   cursor: pointer;
   transition: transform 120ms ease, background 120ms ease, opacity 120ms ease;
 }
@@ -380,7 +383,7 @@ button:disabled {
 .scope-context.empty,
 .empty-state {
   color: var(--muted);
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(0, 18, 8, 0.72);
 }
 
 .scope-shell {
@@ -479,7 +482,7 @@ button:disabled {
 .post-card.active,
 .thread-card.active {
   border-color: var(--accent);
-  background: linear-gradient(180deg, var(--accent-soft), rgba(255, 255, 255, 0.94));
+  background: linear-gradient(180deg, var(--accent-soft), rgba(1, 34, 14, 0.94));
 }
 
 .channel-item-top,
@@ -543,11 +546,11 @@ button:disabled {
 
 .message-card.active {
   border-color: var(--accent);
-  box-shadow: inset 0 0 0 1px rgba(15, 107, 90, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 102, 0.28);
 }
 
 .message-card:focus-visible {
-  outline: 3px solid rgba(15, 107, 90, 0.22);
+  outline: 3px solid rgba(0, 255, 102, 0.34);
   outline-offset: 2px;
 }
 
@@ -564,13 +567,13 @@ button:disabled {
 }
 
 .relay-badge {
-  background: rgba(81, 102, 214, 0.14);
+  background: rgba(77, 248, 255, 0.14);
   color: var(--discord);
 }
 
 .handoff-badge {
-  background: rgba(191, 149, 84, 0.16);
-  color: #8a5a15;
+  background: rgba(118, 255, 159, 0.16);
+  color: var(--accent-strong);
 }
 
 .pill {
@@ -579,7 +582,7 @@ button:disabled {
   justify-content: center;
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(15, 107, 90, 0.12);
+  background: rgba(0, 255, 102, 0.14);
   color: var(--accent-strong);
   font-size: 0.76rem;
   font-weight: 700;
@@ -630,7 +633,7 @@ button:disabled {
   padding: 12px 14px;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(0, 18, 8, 0.82);
 }
 
 .project-pulse-artifacts {
@@ -649,7 +652,7 @@ button:disabled {
   padding: 12px 14px;
   border-radius: 16px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.76);
+  background: rgba(0, 18, 8, 0.76);
 }
 
 .project-pulse-artifact-label,
@@ -698,7 +701,7 @@ button:disabled {
   padding: 14px;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(0, 18, 8, 0.82);
 }
 
 .project-pulse-stat-value {
@@ -713,23 +716,23 @@ button:disabled {
 }
 
 .project-pulse-stat-execute-now {
-  background: rgba(11, 122, 86, 0.12);
+  background: rgba(0, 255, 102, 0.14);
 }
 
 .project-pulse-stat-done {
-  background: rgba(15, 107, 90, 0.08);
+  background: rgba(0, 255, 102, 0.1);
 }
 
 .project-pulse-stat-in-progress {
-  background: rgba(15, 107, 90, 0.1);
+  background: rgba(0, 255, 102, 0.12);
 }
 
 .project-pulse-stat-queued {
-  background: rgba(191, 149, 84, 0.12);
+  background: rgba(118, 255, 159, 0.12);
 }
 
 .project-pulse-stat-parked {
-  background: rgba(95, 108, 102, 0.08);
+  background: rgba(131, 184, 154, 0.1);
 }
 
 .project-pulse-lanes {
@@ -745,16 +748,16 @@ button:disabled {
   padding: 14px;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.84);
+  background: rgba(0, 18, 8, 0.84);
 }
 
 .project-pulse-lane.focus {
-  border-color: rgba(15, 107, 90, 0.3);
-  box-shadow: inset 0 0 0 1px rgba(15, 107, 90, 0.1);
+  border-color: rgba(0, 255, 102, 0.46);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 102, 0.18);
 }
 
 .project-pulse-lane .project-pulse-artifact {
-  background: rgba(255, 255, 255, 0.88);
+  background: rgba(1, 34, 14, 0.88);
 }
 
 .project-pulse-lane-heading {
@@ -767,23 +770,23 @@ button:disabled {
 .pulse-pill-done,
 .pulse-pill-execute-now,
 .pulse-pill-success {
-  background: rgba(11, 122, 86, 0.14);
+  background: rgba(0, 255, 102, 0.16);
   color: var(--success);
 }
 
 .pulse-pill-in-progress {
-  background: rgba(15, 107, 90, 0.12);
+  background: rgba(0, 255, 102, 0.14);
   color: var(--accent-strong);
 }
 
 .pulse-pill-queued {
-  background: rgba(191, 149, 84, 0.16);
-  color: #8a5a15;
+  background: rgba(118, 255, 159, 0.16);
+  color: var(--accent-strong);
 }
 
 .pulse-pill-parked,
 .pulse-pill-watching {
-  background: rgba(95, 108, 102, 0.12);
+  background: rgba(131, 184, 154, 0.12);
   color: var(--muted);
 }
 
@@ -805,7 +808,7 @@ button:disabled {
   padding: 12px 14px;
   border-radius: 16px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(0, 18, 8, 0.8);
 }
 
 .service-health-metric strong {
@@ -835,7 +838,7 @@ button:disabled {
   flex-direction: column;
   gap: 12px;
   padding: 14px;
-  background: rgba(255, 255, 255, 0.86);
+  background: rgba(0, 18, 8, 0.86);
 }
 
 .attachment-shell-top {
@@ -877,14 +880,14 @@ button:disabled {
 
 .attachment-remove,
 .ghost-button {
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(0, 18, 8, 0.6);
   color: var(--accent-strong);
-  border: 1px solid rgba(15, 107, 90, 0.18);
+  border: 1px solid rgba(0, 255, 102, 0.26);
 }
 
 .attachment-remove:hover:not(:disabled),
 .ghost-button:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.94);
+  background: rgba(2, 54, 22, 0.94);
 }
 
 .attachment-empty,
@@ -914,8 +917,8 @@ button:disabled {
 }
 
 .attachment-pill {
-  background: rgba(191, 149, 84, 0.14);
-  color: #8a5a15;
+  background: rgba(118, 255, 159, 0.14);
+  color: var(--accent-strong);
 }
 
 .compact-composer {
@@ -949,7 +952,7 @@ button:disabled {
   padding: 12px 14px;
   border: 1px solid var(--line);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.78);
+  background: rgba(0, 18, 8, 0.78);
 }
 
 .linked-context-search-field {
@@ -972,7 +975,7 @@ button:disabled {
 
 .linked-context-filter-button.active {
   background: var(--accent);
-  color: white;
+  color: var(--bg-deep);
   border-color: transparent;
 }
 
@@ -983,7 +986,7 @@ button:disabled {
   padding: 14px;
   border: 1px solid var(--line);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.68);
+  background: rgba(0, 18, 8, 0.68);
 }
 
 .linked-context-group-header {
@@ -1011,7 +1014,7 @@ button:disabled {
   padding: 14px;
   border: 1px solid var(--line);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(0, 18, 8, 0.8);
 }
 
 .link-action-row {
@@ -1037,7 +1040,7 @@ button:disabled {
 
 .coordination-focus-button.active {
   background: var(--accent);
-  color: white;
+  color: var(--bg-deep);
   border-color: transparent;
 }
 
@@ -1119,7 +1122,7 @@ button:disabled {
 
 .status.success {
   color: var(--success);
-  background: rgba(11, 122, 86, 0.1);
+  background: rgba(0, 255, 102, 0.12);
 }
 
 .status.error {
@@ -1143,7 +1146,7 @@ pre {
   padding: 16px;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.84);
+  background: rgba(0, 18, 8, 0.84);
   white-space: pre-wrap;
 }
 

--- a/config/runtime-packages/helper-review.example.json
+++ b/config/runtime-packages/helper-review.example.json
@@ -25,6 +25,10 @@
     {
       "surfacePackageId": "nexus.surface.direct",
       "slotId": "participant-card"
+    },
+    {
+      "surfacePackageId": "nexus.surface.timeline",
+      "slotId": "timeline-filter"
     }
   ],
   "presentationHooks": [

--- a/config/runtime-packages/surface-timeline.example.json
+++ b/config/runtime-packages/surface-timeline.example.json
@@ -1,0 +1,38 @@
+{
+  "packageId": "nexus.surface.timeline",
+  "displayName": "NEXUS Timeline Surface",
+  "manifestVersion": "1",
+  "abiVersion": "1",
+  "surfaceKind": "timeline",
+  "entrypoint": {
+    "runtime": "native-c",
+    "symbol": "nexus_surface_timeline_bootstrap"
+  },
+  "hostCapabilities": [
+    "conversation.read",
+    "coordination.focus",
+    "route.selection"
+  ],
+  "routing": {
+    "scopeType": "timeline",
+    "requiresMessageStream": true,
+    "allowsCrossScopeResults": true
+  },
+  "helperSlots": [
+    {
+      "slotId": "timeline-filter",
+      "allowedKinds": [
+        "inspector",
+        "review-helper"
+      ]
+    }
+  ],
+  "failurePolicy": {
+    "onCrash": "degrade-surface",
+    "onIncompatibleHelper": "reject-helper"
+  },
+  "compatibility": {
+    "minHost": "nexus-host-avalonia@1",
+    "minRuntime": "nexus-runtime-core@1"
+  }
+}

--- a/docs/architecture-contract.md
+++ b/docs/architecture-contract.md
@@ -1,0 +1,153 @@
+# NEXUS Architecture Contract
+
+## Purpose
+
+This contract bounds issue `#57` architecture alignment.
+
+NEXUS is a container interface for multiple component programs. It hosts conversation surfaces and approved helper programs without absorbing their runtime identity, package ownership, or registry authority.
+
+This contract also pins the language boundary for the target desktop direction: Native C is the runtime and interop default, Avalonia is the desktop host, C# is minimal host glue, and C++ is permitted only where there is no narrower production-quality option.
+
+## Architectural invariant
+
+NEXUS must stay a host/container, not a monolithic application that rewrites every component into one runtime.
+
+The stable system shape is:
+
+1. a Native C runtime core owns supervision, package activation, failure isolation, lifecycle state, and the C ABI boundary
+2. an Avalonia host owns windows, rendering, input, accessibility, and operator-visible recovery
+3. minimal C# glue connects Avalonia host events to the Native C interop boundary
+4. surface programs implement NEXUS route-local conversation experiences
+5. helper programs remain owned by their source runtime and are embedded only through approved package metadata, capability declarations, and slot contracts
+
+## Language and runtime rules
+
+### Native C
+
+Native C is the default implementation language for:
+
+- long-lived runtime supervision
+- package and manifest validation
+- capability checks
+- helper activation, termination, and restart policy
+- runtime event envelopes
+- the versioned interop ABI consumed by the desktop host
+
+Native C also owns the outward ABI even when an implementation detail behind the ABI is not written in C.
+
+### Avalonia and C#
+
+Avalonia is the target desktop host where a managed desktop shell is still useful.
+
+C# must stay thin and host-facing. It may own:
+
+- Avalonia application bootstrap
+- window and route wiring
+- accessibility and input dispatch into the host surface
+- conversion between host events and the Native C ABI calls
+- operator-visible diagnostics and recovery affordances
+
+C# must not become the owner of:
+
+- package registry truth
+- helper identity
+- long-lived process supervision
+- compatibility policy
+- NEXUS domain semantics that belong in the runtime/service contract
+
+### C++
+
+C++ is not a default NEXUS architecture language.
+
+C++ may be introduced only when all of these are true:
+
+- the need is bounded to a concrete component, adapter, or platform/vendor integration
+- a C implementation or existing C ABI is not viable for the production requirement
+- the C++ code is hidden behind the same Native C ABI or a narrower private C facade
+- no C++ standard library, exception, RTTI, template, ownership, allocator, or object-lifetime type crosses the runtime interop boundary
+- build, packaging, crash, and diagnostic behavior can be isolated from the rest of the runtime
+
+C++ must not be used for:
+
+- conversation-domain modeling
+- package manifest semantics
+- NEXUS route or surface identity
+- Avalonia presentation glue
+- helper ownership policy
+- public interop contracts
+
+If C++ is required for a component, the component contract must document why Native C is insufficient, the C facade it exposes, its failure isolation boundary, and the removal or replacement path if a C-native option becomes available.
+
+## Container interface contract
+
+NEXUS hosts component programs through explicit contracts.
+
+The concrete runtime container interface is defined in [runtime-container-interface.md](runtime-container-interface.md).
+
+Every component program must have:
+
+- stable package identity
+- source runtime identity when imported from another system
+- declared capabilities
+- compatible ABI or host protocol version
+- lifecycle policy
+- failure policy
+- operator-visible diagnostic envelope
+
+NEXUS may provide:
+
+- route resolution
+- surface slots
+- helper slots
+- capability mediation
+- rendering frame and host affordances
+- recovery and degraded-state presentation
+
+NEXUS must not provide by implication:
+
+- foreign package ownership
+- source-runtime identity rewriting
+- silent capability widening
+- cross-component shared mutable state
+- host-only placement rules as a substitute for manifest compatibility
+
+## Component program families
+
+### Surface programs
+
+Surface programs are NEXUS-owned route-local programs for channels, forums, threads, timelines, and direct conversations.
+
+They bind to the current actor, workspace, route, package manifest, approved host capabilities, and optional helper slots. A surface program failure must not corrupt unrelated route state.
+
+### Helper programs
+
+Helper programs are imported or adjacent programs that NEXUS embeds into approved slots.
+
+They remain attributable to their source runtime, such as `SYMBIOSIS`, and must declare their capabilities, slot targets, hosting mode, and failure behavior before activation. A helper failure must degrade the affected slot, not the whole NEXUS route.
+
+### Runtime components
+
+Runtime components provide supervision, activation, manifest validation, diagnostics, and lifecycle events.
+
+They are not presentation components. They expose stable Native C interop contracts and must keep failure behavior explicit and machine-readable.
+
+## Interop rule
+
+The desktop host talks to the runtime through a versioned Native C boundary.
+
+Interop payloads may use JSON or flat C-ABI-safe structs for route, actor, package, command, and event data. Public interop contracts must return explicit handles, structured payloads, and stable error codes.
+
+No component may require Avalonia or C# callers to understand C++ object identity, ownership, exceptions, allocator rules, templates, or private runtime memory.
+
+## Compatibility and migration
+
+The current Electron shell and Node-managed service remain the continuity baseline until replacement work lands in production code.
+
+Migration must preserve:
+
+- the current operator-visible service contract while the Native C runtime is introduced behind it
+- package and capability manifests as the compatibility source for future surface and helper activation
+- explicit failure diagnostics across runtime, host, surface, and helper boundaries
+- a later Avalonia host swap that consumes the same Native C interop contract instead of inventing a second runtime authority
+
+This contract narrows the long-term target without claiming that the current repository already contains the target runtime or Avalonia host.

--- a/docs/runtime-container-interface.md
+++ b/docs/runtime-container-interface.md
@@ -1,0 +1,97 @@
+# NEXUS Runtime Container Interface
+
+## Purpose
+
+This record makes the NEXUS container model explicit for issue `#57`.
+
+NEXUS is the host interface for multiple component programs. It is not a single monolithic program that absorbs every surface, helper, and external runtime into one ownership model.
+
+## Interface contract
+
+The runtime container has three public responsibilities:
+
+- resolve a route into one approved surface program
+- reserve approved helper slots for that surface program
+- supervise component lifecycle, failures, and diagnostics through the Native C runtime boundary
+
+The public runtime boundary must stay Native C first. Avalonia consumes that boundary as the desktop host. C# is limited to Avalonia hosting and thin glue. C++ is allowed only inside isolated component internals when Native C is not viable, and it must stay hidden behind a Native C facade.
+
+## Expected inputs
+
+Container activation accepts:
+
+- actor identity
+- workspace identity
+- route scope and surface kind
+- selected surface package identity
+- declared route capabilities
+- optional helper slot requests
+- manifest and ABI versions
+
+Inputs may be JSON envelopes or flat C-ABI-safe structs. They must not require callers to understand C++ object identity, allocator rules, exceptions, RTTI, templates, or private runtime memory.
+
+## Expected outputs
+
+The container returns:
+
+- stable runtime, surface, and helper handles
+- structured activation results
+- helper-slot reservation or degradation state
+- lifecycle and recovery event envelopes
+- explicit machine-readable error codes
+
+Avalonia may render those outputs, but it does not become the runtime authority.
+
+## Error behavior
+
+The container must reject activation before operator-visible mounting when:
+
+- the surface package is missing
+- `surfaceKind` is unsupported
+- `entrypoint.runtime` is not `native-c`
+- ABI or manifest versions are incompatible
+- required capabilities are denied
+- requested helper slots are undeclared
+- helper packages target the wrong surface or slot
+- a component fails its startup or health handshake
+
+Failure isolation rules:
+
+- one helper crash degrades that helper slot
+- one surface failure degrades that route-local surface
+- runtime supervisor failure is visible through health and recovery diagnostics
+- unrelated routes and helpers must not be corrupted by a single component failure
+
+## Compatibility and versioning
+
+- `manifestVersion` governs package-manifest shape.
+- `abiVersion` governs the Native C runtime boundary.
+- host/runtime compatibility is declared through package metadata such as `nexus-host-avalonia@1` and `nexus-runtime-core@1`.
+- package upgrades must not silently widen capabilities or cross ownership boundaries.
+
+The current Electron and Node implementation remains a continuity baseline only. The migration path must keep the HTTP/operator surface usable while moving runtime ownership under this container interface.
+
+## Example usage
+
+```json
+{
+  "actorId": "identity-jack",
+  "workspaceId": "workspace-internal-core",
+  "surfaceKind": "timeline",
+  "scopeId": "timeline-internal-core",
+  "surfacePackageId": "nexus.surface.timeline",
+  "routeCapabilities": [
+    "conversation.read",
+    "coordination.focus",
+    "route.selection"
+  ],
+  "helperSlotRequests": [
+    {
+      "slotId": "timeline-filter",
+      "preferredHelperPackageId": "symbiosis.helper.review"
+    }
+  ]
+}
+```
+
+The expected result is a route-local timeline surface handle, a reserved or bound `timeline-filter` helper slot, and runtime events that explain any degraded component without collapsing the whole NEXUS container.

--- a/docs/runtime-package-manifests.md
+++ b/docs/runtime-package-manifests.md
@@ -5,6 +5,7 @@
 This record turns the `#57` topology split into concrete package-manifest shapes that future runtime work can implement without reopening the topology decision.
 
 These manifests are packaging contracts, not a claim that the native runtime is already landed.
+They feed the [runtime container interface](runtime-container-interface.md), which activates route-local surface programs and helper slots through the Native C runtime boundary.
 
 ## Interface contract
 
@@ -57,12 +58,14 @@ The runtime should reject a surface manifest when:
 - `abiVersion` is incompatible
 - `surfaceKind` is unknown
 - `entrypoint` is missing
+- `entrypoint.runtime` is not `native-c`
 - a required host capability is undeclared or unsupported
 
 ### Compatibility and versioning
 
 - `manifestVersion` governs manifest-shape evolution
 - `abiVersion` governs runtime boundary compatibility
+- public surface entrypoints must stay Native C ABI entrypoints; C++ internals, when justified, must remain hidden behind a Native C facade
 - package upgrades must not silently widen required capabilities
 
 Example file: [surface-thread.example.json](../config/runtime-packages/surface-thread.example.json)
@@ -132,9 +135,11 @@ The future native runtime should:
 The next records that build directly on these manifest contracts are:
 
 - [runtime-first-migration-seam.md](runtime-first-migration-seam.md)
+- [runtime-container-interface.md](runtime-container-interface.md)
 - [conversation-surface-program-model.md](conversation-surface-program-model.md)
 
 ## Initial manifest files
 
 - [surface-thread.example.json](../config/runtime-packages/surface-thread.example.json)
+- [surface-timeline.example.json](../config/runtime-packages/surface-timeline.example.json)
 - [helper-review.example.json](../config/runtime-packages/helper-review.example.json)

--- a/docs/runtime-topology.md
+++ b/docs/runtime-topology.md
@@ -6,6 +6,8 @@ This record defines the first concrete packaging and runtime split for NEXUS iss
 
 The goal is to make the native-C-first target explicit without pretending the current Electron and Node baseline has already been replaced.
 
+This topology is governed by the bounded [architecture contract](architecture-contract.md) and the [runtime container interface](runtime-container-interface.md), including the rule that NEXUS is a container interface for multiple component programs and that C++ is allowed only for narrowly justified component internals hidden behind a Native C facade.
+
 ## Topology decision
 
 The target desktop stack is a four-part system:
@@ -20,6 +22,8 @@ The target desktop stack is a four-part system:
    Imported helper programs attached to surface hosts through explicit capability metadata and registry ownership, not by implicit process co-ownership.
 
 The current Electron shell and Node-managed service remain the continuity baseline and migration source.
+
+The target stack is not a C++ desktop rewrite. Native C owns runtime and interop responsibilities, Avalonia owns the desktop host, C# remains thin host glue, and surface/helper programs are loaded as explicit components through package metadata.
 
 ## Ownership split
 
@@ -40,6 +44,7 @@ Native C does not own:
 - Avalonia view composition
 - presentation-only helper styling
 - operator copy that belongs to PRISM or other external style authorities
+- C++ object models or private allocator lifetimes at the public host boundary
 
 ### Avalonia host
 
@@ -56,6 +61,7 @@ Avalonia does not own:
 - helper runtime identity
 - long-lived native process supervision
 - registry truth for imported helper packages
+- runtime policy hidden in C# glue
 
 ### Registry and external authorities
 
@@ -64,6 +70,8 @@ Avalonia does not own:
 NEXUS renders and hosts imported helper surfaces, but it must not absorb their runtime authority or rewrite their registry identity.
 
 ## Packaging units
+
+NEXUS package loading treats the product as a container for component programs. Surface packages are NEXUS-owned route-local programs. Helper packages are imported or adjacent programs with source-runtime identity and explicit slot permissions. Runtime components provide supervision and activation services but do not become presentation owners.
 
 ### Surface package
 
@@ -190,5 +198,6 @@ The target stack is therefore explicit, but the current mainline baseline remain
 ## Current concrete follow-ons
 
 - [runtime-package-manifests.md](runtime-package-manifests.md) pins the first concrete surface-package and helper-package manifest shapes against this topology.
+- [runtime-container-interface.md](runtime-container-interface.md) names the runtime container contract for route-local surface programs and helper slots.
 - [runtime-first-migration-seam.md](runtime-first-migration-seam.md) chooses the first replacement seam away from Electron without breaking the verified continuity baseline.
 - [conversation-surface-program-model.md](conversation-surface-program-model.md) activates the first child-program model for channel, forum, thread, timeline, and direct surfaces against those manifest contracts.

--- a/test/service.test.mjs
+++ b/test/service.test.mjs
@@ -1,12 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createNexusService } from '../apps/service/src/server.mjs';
 import { resolveServiceConfig } from '../apps/service/src/lib/config.mjs';
 import { createInProcessRuntimeAdapter } from '../apps/service/src/lib/runtime-adapter.mjs';
+import { createRuntimeManifestRegistry } from '../apps/service/src/lib/runtime-manifest-registry.mjs';
 import { createStore } from '../apps/service/src/lib/store-factory.mjs';
 
 async function withService(run) {
@@ -34,6 +35,37 @@ function createFailingManifestRegistry(code = 'TEST_RUNTIME_SUPERVISOR_BOOT_FAIL
   };
 }
 
+test('runtime manifest registry rejects surface packages without native-c entrypoints', async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'nexus-manifest-'));
+  const manifestDirectory = join(repoRoot, 'config', 'runtime-packages');
+  await mkdir(manifestDirectory, { recursive: true });
+  await writeFile(join(manifestDirectory, 'surface-invalid.example.json'), JSON.stringify({
+    packageId: 'nexus.surface.invalid',
+    displayName: 'Invalid Surface',
+    manifestVersion: '1',
+    abiVersion: '1',
+    surfaceKind: 'thread',
+    entrypoint: {
+      runtime: 'cpp',
+      symbol: 'nexus_surface_invalid_bootstrap'
+    },
+    hostCapabilities: ['conversation.read'],
+    routing: {
+      scopeType: 'thread'
+    },
+    failurePolicy: {
+      onCrash: 'degrade-surface'
+    }
+  }));
+
+  const registry = createRuntimeManifestRegistry({ repoRoot });
+
+  await assert.rejects(
+    () => registry.getSummary(),
+    /entrypoint\.runtime as native-c/
+  );
+});
+
 test('service boots and exposes the seeded internal channel map', async () => {
   await withService(async (service) => {
     const health = await fetch(`${service.url}/api/health`).then((response) => response.json());
@@ -56,7 +88,7 @@ test('service boots and exposes the seeded internal channel map', async () => {
     assert.equal(health.runtime.lastLifecycleRequest, null);
     assert.equal(health.runtime.activeRouteActivationCount, 0);
     assert.deepEqual(health.runtime.activeRouteActivations, []);
-    assert.equal(health.runtime.manifestRegistry.surfacePackageCount, 4);
+    assert.equal(health.runtime.manifestRegistry.surfacePackageCount, 5);
     assert.equal(health.runtime.manifestRegistry.helperPackageCount, 1);
     assert.equal(health.runtime.supervisor.transitionSeam, 'service-runtime-supervisor-boundary');
     assert.equal(health.runtime.supervisor.readiness, 'ready');
@@ -300,6 +332,43 @@ test('route activation resolves a manifest-backed direct surface and compatible 
     assert.equal(activation.surface.packageId, 'nexus.surface.direct');
     assert.equal(activation.helperSlots.length, 1);
     assert.equal(activation.helperSlots[0].status, 'bound');
+    assert.deepEqual(activation.diagnostics, []);
+  });
+});
+
+test('route activation resolves a manifest-backed timeline surface and compatible helper slot', async () => {
+  await withService(async (service) => {
+    const activationResponse = await fetch(`${service.url}/api/runtime/route-activations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        actorId: 'identity-jack',
+        workspaceId: 'workspace-internal-core',
+        surfaceKind: 'timeline',
+        scopeId: 'timeline-internal-core',
+        surfacePackageId: 'nexus.surface.timeline',
+        routeCapabilities: [
+          'conversation.read',
+          'coordination.focus',
+          'route.selection'
+        ],
+        helperSlotRequests: [
+          {
+            slotId: 'timeline-filter',
+            preferredHelperPackageId: 'symbiosis.helper.review'
+          }
+        ]
+      })
+    });
+    const activation = await activationResponse.json();
+
+    assert.equal(activationResponse.status, 200);
+    assert.equal(activation.route.surfaceKind, 'timeline');
+    assert.equal(activation.route.scopeId, 'timeline-internal-core');
+    assert.equal(activation.surface.packageId, 'nexus.surface.timeline');
+    assert.equal(activation.helperSlots.length, 1);
+    assert.equal(activation.helperSlots[0].status, 'bound');
+    assert.equal(activation.helperSlots[0].helper.packageId, 'symbiosis.helper.review');
     assert.deepEqual(activation.diagnostics, []);
   });
 });


### PR DESCRIPTION
## Summary
- codifies the NEXUS native-container architecture contract for issue #57, including Native C runtime ownership, Avalonia host ownership, minimal C# glue, and C++ only as hidden component internals when Native C is not viable
- adds the named runtime container interface for surface/helper component programs and links it from the README/runtime topology/package manifest docs
- adds a timeline surface package and helper slot target, enforces `entrypoint.runtime: native-c` in manifest loading, and covers both with service tests
- shifts the current continuity UI from the white/beige theme to a Matrix Code visual direction and updates Project Pulse truth

## Verification
- node --check apps/service/src/lib/runtime-manifest-registry.mjs
- node --check test/service.test.mjs
- JSON parse for project-progress and runtime-package JSON files
- git diff --check (CRLF normalization warnings only)
- npm test (90/90)
- service smoke: /api/health ok, 5 surface packages, timeline activation 200 with bound helper slot

Refs #57
